### PR TITLE
Edits lead in the same pop up window as show

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -29,8 +29,7 @@ class LeadsController < ApplicationController
   def update
     @lead = Lead.find(params[:id])
     @lead.update(lead_params)
-    redirect_to leads_path
-    flash[:notice] = "Lead# #{@lead.id} was successfully updated"
+    flash.now[:notice] = "Lead# #{@lead.id} was successfully updated"
   end
 
   def search_lead

--- a/app/views/leads/_show.html.erb
+++ b/app/views/leads/_show.html.erb
@@ -3,14 +3,36 @@
     <div class=""> -->
       <div class="lead-show">
         <!-- <h1 class="text-center"><b></b>Lead# <%#= @lead.id %></h1> -->
-        <p><b>Name:</b> <%= @lead.name %></p>
-        <p><b>Company:</b> <%= @lead.company %></p>
-        <p><b>Email:</b> <%= @lead.email %></p>
-        <p><b>Phone:</b> <%= @lead.phone %></p>
-        <p><b>Message:</b> <%= @lead.message %></p>
+        <%= simple_form_for @lead, remote: true do |f| %>
+        <%= render 'shared/flashes' %>
+        <div class="flex">
+          <p><b>Name:</b> <%= @lead.name %></p>
+          <a><i id="name" class="fas fa-pencil-alt fa-spin"></i></a>
+        </div>
+          <%= f.input :name, label: false, input_html: { class: 'special n' }%>
+        <div class="flex">
+          <p><b>Company:</b> <%= @lead.company %></p>
+          <a><i id="company" class="fas fa-pencil-alt fa-spin"></i></a>
+        </div>
+          <%= f.input :company, label: false, input_html: { class: 'special c' }%>
+        <div class="flex">
+          <p><b>Email:</b> <%= @lead.email %></p>
+          <a><i id="email" class="fas fa-pencil-alt fa-spin"></i></a>
+        </div>
+          <%= f.input :email, label: false, input_html: { class: 'special e' }%>
+        <div class="flex">
+          <p><b>Phone:</b> <%= @lead.phone %></p>
+          <a><i id="phone" class="fas fa-pencil-alt fa-spin"></i></a>
+        </div>
+          <%= f.input :phone, label: false, input_html: { class: 'special p' }%>
+        <div class="flex">
+          <p><b>Message:</b> <%= @lead.message %></p>
+          <a><i id="message" class="fas fa-pencil-alt fa-spin"></i></a>
+        </div>
+          <%= f.input :message, label: false, input_html: { class: 'special m' }%>
         <p><b>Status:</b> <%= @lead.status %></p>
+        <p><%= f.submit "Update Details", class: "btn btn-success" %></p>
         <hr>
-        <%= simple_form_for @lead do |f| %>
         <p><b>Change Status:</b> <%= f.input :status, label: false, as: :select, collection: ["Open - Not Contacted", "Working - Contacted", "Closed - Converted", "Closed - Not Connected"] %></p>
         <p><%= f.submit "Update Status", class: 'btn btn-info' %></p>
         <% end %>
@@ -19,8 +41,33 @@
   </div>
 </div> -->
 
+<script>
+  $('.special').hide();
+  $('.btn-success').hide();
+  var leadShowIds = ["#name", "#company", "#email", "#phone", "#message"];
+  var leadEditClasses = [".n", ".c", ".e", ".p", ".m"];
+  leadShowIds.forEach(function(value, indexOfIds) {
+    $(value).click(function(){
+      leadEditClasses.forEach(function(val, indexOfClasses) {
+        if (indexOfIds == indexOfClasses) {
+          $(val).toggle(450);
+          $('.btn-success').toggle(550);
+        }
+      })
+    })
+  })
+  // $('#name').on("click",function(){
+  //   $('#name').toggle(500);
+  // })
+</script>
+
 
 <style>
+  .flex {
+    display: flex;
+    justify-content:space-between;
+  }
+
   .lead-show {
     border-radius:5px;
     background: white;

--- a/app/views/leads/update.js.coffee
+++ b/app/views/leads/update.js.coffee
@@ -1,0 +1,1 @@
+$('.bootbox-body').html '<%= escape_javascript(render partial: "show") %>'


### PR DESCRIPTION
Edits lead in the same pop up window as show and redirects back to the same popup window. 
Achieved by using a new coffee script for update method where it update the content on the bootbox dialog without having to refresh or leave the page
In the form we had to add remote true
Render flashes was also added to the form to makesure that the flash appears within the bootbox dialog only