### PR TITLE
Every new lead will now have a new badge until viewed

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -6,6 +6,8 @@ class LeadsController < ApplicationController
 
   def show
     @lead = Lead.find(params[:id])
+    @lead.viewed = true
+    @lead.save
   end
 
   def new

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -15,6 +15,9 @@
       <div class="col-xs-12 col-sm-4 scale">
         <div class="lead-name">
           <p>Name: <%= l.name %></p>
+        <% if l.viewed == false %>
+          <div class="badge">new</div>
+        <% end %>
         </div>
         <div class="lead-body">
           <p>Email: <%= l.email %></p>
@@ -52,6 +55,13 @@
 
 
 <style>
+  .badge {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    border-radius: 50%;
+  }
+
   .pagination {
     display: block;
     margin:0;
@@ -77,6 +87,8 @@
   }
 
   .lead-name {
+    display: flex;
+    justify-content: space-between;
     background-color:#0198EB;
     padding:5px;
     margin-left:5px;

--- a/app/views/leads/show.js.coffee
+++ b/app/views/leads/show.js.coffee
@@ -8,3 +8,9 @@ bootbox.dialog
         className: 'btn-danger'
     }
   }
+
+$('.bootbox-close-button').click ->
+  #location.reload()
+  #window.location = window.location
+  window.location.reload()
+  return

--- a/db/migrate/20180530113144_add_viewed_to_leads.rb
+++ b/db/migrate/20180530113144_add_viewed_to_leads.rb
@@ -1,0 +1,5 @@
+class AddViewedToLeads < ActiveRecord::Migration[5.2]
+  def change
+    add_column :leads, :viewed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_09_105443) do
+ActiveRecord::Schema.define(version: 2018_05_30_113144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2018_05_09_105443) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "viewed", default: false
   end
 
 end


### PR DESCRIPTION
Each new lead has a new badge on it whether it is retrieved or created manually
This is then removed once the lead is viewed.