### PR TITLE
Product type in Contacts has been changed from String to an Array

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -43,7 +43,7 @@ class ContactsController < ApplicationController
   private
 
   def contact_params
-    params.require(:contact).permit(:name, :company, :email, :phone, :address, :city, :postcode)
+    params.require(:contact).permit(:name, :company, :email, :phone, :address, :city, :postcode, product: [])
   end
 
 end

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -37,20 +37,24 @@
       <a><i id="postcode" class="fas fa-pencil-alt fa-spin"></i></a>
     </div>
       <%= f.input :postcode, label: false, input_html: { class: 'special po' }%>
+      <%= f.label "Interest In Products:" %> <%= @contact.product != nil ? @contact.product.join(", ") : nil%>
     <div class="text-right">
-
       <%= link_to contact_path(@contact), method: :delete, data: {confirm: 'Are you sure?', title: "Deleting Contact# #{@contact.id}"} do %>
         <i class="far fa-trash-alt"></i>
       <% end %>
     </div>
     <%= f.submit "Update Details", class: "btn btn-warning update-details" %>
     <hr>
-    <%#= f.select(:product, options_for_select( [[ 'Pharmacy', ['Caremeds', 'eMAR', 'MultiMeds']], [ 'Carehome', ['Frau', 'Frau']]] ), { 'data-width' => "100%", :class => "selectpicker"} ) %>
+    <%#= f.select(:product, options_for_select( [[ 'Pharmacy', ['Caremeds', 'eMAR', 'MultiMeds']], [ 'Carehome', ['Frau', 'Frau']]] ), { 'data-width' => "100%", :class =>
+    "selectpicker"} ) %>
+    <% counter = 0 %>
     <%= f.input :product,
+
      # :include_blank => false,
      :as => :grouped_select,
-     :collection => Proc.new { [['Pharmacy', ['Caremeds', 'eMAR', 'MultiMeds']], ['Carehome', ['eMAR', 'MultiMeds']]] },
+     :collection => [['Pharmacy', ['Caremeds', 'eMAR', 'MultiMeds']], ['Carehome', ['e-MAR', 'Multi-Meds']]],
      :group_method => :last,
+     include_hidden: false,
      :input_html => { class: 'selectpicker', multiple: true } %>
      <%= f.submit "Add Product", class: "btn btn-success" %>
      <hr>

--- a/db/migrate/20180606094300_add_products_to_contacts.rb
+++ b/db/migrate/20180606094300_add_products_to_contacts.rb
@@ -1,5 +1,5 @@
 class AddProductsToContacts < ActiveRecord::Migration[5.2]
   def change
-    add_column :contacts, :product, :string
+    add_column :contacts, :product, :string, array: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2018_06_06_094300) do
     t.bigint "lead_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "product"
+    t.string "product", array: true
     t.index ["lead_id"], name: "index_contacts_on_lead_id"
   end
 


### PR DESCRIPTION
Now multiple values of a product can be stored dependent on the type of contact. The schema for products was amended to include array to be true for the product which is of a type string. 